### PR TITLE
Added support for IPv4 in CIDR notation and updated list of allowed IPs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,10 @@
         "php": ">=5.3.3",
         "predis/predis": "0.8.*"
     },
+    "autoload": {
+        "psr-0": { "": "src/" },
+        "files": [ "src/functions.php" ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"

--- a/composer.lock
+++ b/composer.lock
@@ -1,30 +1,36 @@
 {
-    "hash": "cb612723e4941c1f52d872cedad00610",
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "f9afd7d58ae850b33ac06703d62b90ab",
     "packages": [
         {
             "name": "predis/predis",
-            "version": "v0.8.0",
+            "version": "v0.8.7",
             "source": {
                 "type": "git",
-                "url": "git://github.com/nrk/predis.git",
-                "reference": "v0.8.0"
+                "url": "https://github.com/nrk/predis.git",
+                "reference": "4123fcd85d61354c6c9900db76c9597dbd129bf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/nrk/predis/zipball/v0.8.0",
-                "reference": "v0.8.0",
+                "url": "https://api.github.com/repos/nrk/predis/zipball/4123fcd85d61354c6c9900db76c9597dbd129bf6",
+                "reference": "4123fcd85d61354c6c9900db76c9597dbd129bf6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
-            "suggest": {
-                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol",
-                "ext-curl": "Allows access to Webdis when paired with phpiredis"
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
             },
-            "time": "2012-10-22 16:46:05",
+            "suggest": {
+                "ext-curl": "Allows access to Webdis when paired with phpiredis",
+                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol"
+            },
             "type": "library",
-            "installation-source": "dist",
             "autoload": {
                 "psr-0": {
                     "Predis": "lib/"
@@ -45,17 +51,27 @@
             "homepage": "http://github.com/nrk/predis",
             "keywords": [
                 "nosql",
-                "redis",
-                "predis"
-            ]
+                "predis",
+                "redis"
+            ],
+            "time": "2014-08-01 09:43:10"
         }
     ],
-    "packages-dev": null,
+    "packages-dev": [
+
+    ],
     "aliases": [
 
     ],
     "minimum-stability": "stable",
     "stability-flags": [
+
+    ],
+    "prefer-stable": false,
+    "platform": {
+        "php": ">=5.3.3"
+    },
+    "platform-dev": [
 
     ]
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Git Subsplit GitHub WebHook package.
+ *
+ * (c) Beau Simensen <beau@dflydev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Match IPv4 address with list of allowed IPv4 (also in CIDR notation) addresses
+ *
+ * @author Piotr Minkina <projekty@piotrminkina.pl>
+ *
+ * @param string $ipAddress IPv4 address, e.g. 127.0.0.1
+ * @param array $allowedIps List of allowed IPv4 addresses, e.g. 127.0.0.0/8, 192.168.1.0/24, 8.8.8.8
+ * @return bool
+ */
+function checkIPv4Address($ipAddress, array $allowedIps)
+{
+    $ipAddress = inet_pton($ipAddress);
+
+    foreach ($allowedIps as $allowedIp) {
+        $subNetSize = 32;
+
+        if (false !== strpos($allowedIp, '/')) {
+            list($allowedIp, $subNetSize) = explode('/', $allowedIp, 2);
+        }
+        $allowedIp = inet_pton($allowedIp);
+        $addressSize = strlen($allowedIp);
+
+        if ($allowedIp === $ipAddress) {
+            return true;
+        } elseif (strlen($ipAddress) !== $addressSize) {
+            continue;
+        }
+
+        $netMask = str_repeat('1', $subNetSize);
+        $netMask = str_pad($netMask, $addressSize * 8, '0');
+        $netMask = str_split($netMask, 8);
+        $netMask = array_map('bindec', $netMask);
+        $netMask = array_map('chr', $netMask);
+        $netMask = join('', $netMask);
+
+        if (($ipAddress & $netMask) === ($allowedIp & $netMask)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/web/subsplit-webhook.php
+++ b/web/subsplit-webhook.php
@@ -8,11 +8,15 @@ $configFilename = file_exists(__DIR__.'/../config.json')
 
 $config = json_decode(file_get_contents($configFilename), true);
 
+/**
+ * See https://help.github.com/articles/what-ip-addresses-does-github-use-that-i-should-whitelist
+ * to get current list of used IP addresses by GitHub.
+ */
 $allowedIps = isset($config['allowed-ips'])
     ? $config['allowed-ips']
-    : array('207.97.227.253', '50.57.128.197', '108.171.174.178');
+    : array('192.30.252.0/22');
 
-if (!in_array($_SERVER['REMOTE_ADDR'], $allowedIps)) {
+if (!checkIPv4Address($_SERVER['REMOTE_ADDR'], $allowedIps)) {
     header('HTTP/1.1 403 Forbidden');
     echo sprintf("Host %s is not allowed to connect.\n", $_SERVER['REMOTE_ADDR']);
     exit;


### PR DESCRIPTION
Hello,

I added support for IPv4 in CIDR notation, because currently GitHub uses 192.30.252.0/22. See https://help.github.com/articles/what-ip-addresses-does-github-use-that-i-should-whitelist for more details. Also I updated list of allowed IPs.

Could You merge my changes with your code?

Regards
Piotr Minkina
