### PR TITLE
Gitlab support

### DIFF
--- a/web/subsplit-webhook.php
+++ b/web/subsplit-webhook.php
@@ -18,10 +18,19 @@ if (!in_array($_SERVER['REMOTE_ADDR'], $allowedIps)) {
     exit;
 }
 
-$body = $_POST['payload'];
+$headers = getallheaders();
+if (isset($headers['Content-Type']) && 'application/json' === $headers['Content-Type']) {
+    $body = file_get_contents('php://input');
+} else {
+    $body = $_POST['payload'];
+}
+
+if (!$body) {
+    header('HTTP/1.1 400 Bad Request', true, 400);
+    exit;
+}
 
 $redis = new Predis\Client();
-
 $redis->lpush('dflydev-git-subsplit:incoming', $body);
 
 echo "Thanks.\n";


### PR DESCRIPTION
Support payload submitted as http body in json.
So now Gitlab webhooks and new Github webhooks are supported (see https://developer.github.com/v3/repos/hooks/#example).
